### PR TITLE
updated proc/spawn syntax to nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ extern crate libc;
 use libc::{c_int, c_uint, c_void};
 use std::io::{IoResult, IoError};
 use std::os::unix::{AsRawFd,Fd};
+use std::thread::Thread;
 
 pub struct EventFD {
     fd: uint,
@@ -92,7 +93,7 @@ impl EventFD {
         let (tx, rx) = std::comm::sync_channel(1);
         let c = self.clone();
 
-        std::thread::Thread::spawn(move || {
+        Thread::spawn(move || {
             loop {
                 match c.read() {
                     Ok(v) => match tx.send_opt(v) {
@@ -156,7 +157,7 @@ fn test_basic() {
 
     assert!(efd.read() == Ok(10));
 
-    std::thread::Thread::spawn(move || {
+    Thread::spawn(move || {
         assert!(cefd.read() == Ok(7));
         assert!(cefd.write(1) == Ok(()));
         assert!(cefd.write(2) == Ok(()));
@@ -223,7 +224,7 @@ fn test_chan() {
     assert!(efd.write(1) == Ok(()));
     tx.send(efd);
 
-    let t = std::thread::Thread::spawn(move || {
+    let t = Thread::spawn(move || {
         let efd = rx.recv();
         assert!(efd.read() == Ok(11))
     }).join();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,12 +9,13 @@ use libc::{c_int, c_uint, c_void};
 use std::io::{IoResult, IoError};
 use std::os::unix::{AsRawFd,Fd};
 
-#[deriving(Send)]
-#[deriving(Sync)]
 pub struct EventFD {
     fd: uint,
     flags: uint,
 }
+
+unsafe impl Send for EventFD {}
+unsafe impl Sync for EventFD {}
 
 /// Construct a semaphore-style EventFD.
 pub const EFD_SEMAPHORE: uint = 0x00001; // 00000001
@@ -91,7 +92,7 @@ impl EventFD {
         let (tx, rx) = std::comm::sync_channel(1);
         let c = self.clone();
 
-        spawn(proc() {
+        std::thread::Thread::spawn(move || {
             loop {
                 match c.read() {
                     Ok(v) => match tx.send_opt(v) {
@@ -101,7 +102,7 @@ impl EventFD {
                     Err(e) => panic!("read failed: {}", e),
                 }
             }
-        });
+        }).detach();
 
         rx
     }
@@ -155,12 +156,12 @@ fn test_basic() {
 
     assert!(efd.read() == Ok(10));
 
-    spawn(proc() {
+    std::thread::Thread::spawn(move || {
         assert!(cefd.read() == Ok(7));
         assert!(cefd.write(1) == Ok(()));
         assert!(cefd.write(2) == Ok(()));
         tx.send(());
-    });
+    }).detach();
 
     assert!(efd.write(7) == Ok(()));
     rx.recv();
@@ -222,10 +223,10 @@ fn test_chan() {
     assert!(efd.write(1) == Ok(()));
     tx.send(efd);
 
-    let t = std::task::try(proc() {
+    let t = std::thread::Thread::spawn(move || {
         let efd = rx.recv();
         assert!(efd.read() == Ok(11))
-    });
+    }).join();
 
     match t {
         Ok(_) => println!("ok"),


### PR DESCRIPTION
This is building but failing tests with a linker error:

    Undefined symbols for architecture x86_64:
      "_eventfd", referenced from:
          EventFD::new::hf82ff66f9f3abc36Uaa in eventfd-16ec7bbf6c737d53.o
    ld: symbol(s) not found for architecture x86_64
    clang: error: linker command failed with exit code 1 (use -v to see invocation)

Using OS X 10.10 Yosemite with:

    transit% clang -v
    Apple LLVM version 6.0 (clang-600.0.56) (based on LLVM 3.5svn)
    Target: x86_64-apple-darwin14.0.0
    Thread model: posix

and:

    transit% rustc --version
    rustc 0.13.0-nightly (fea5aa656 2014-12-30 00:42:13 +0000)