### PR TITLE
Alter dependency specification to compile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,5 @@ readme = "README.md"
 license = "MIT"
 
 [dependencies.nix]
-git = "https://github.com/carllerche/nix-rust.git"
-features = [ "eventfd" ]
+features=["eventfd"]
+version="*"


### PR DESCRIPTION
+Tested with nightly and stable as of 8-22-2016
+Previously, the dependency specification wasn't compiling for nightly.

Error (for stable and for nightly):

eventfd.rs:7:15: 7:26 error: no rules expected the token `EFD_CLOEXEC
