### PR TITLE
Update the library to work with the latest rust version 1.31.0-nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,12 @@
 [package]
 
 name = "eventfd"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Jeremy Fitzhardinge <jeremy@goop.org>"]
 description = "Binding to Linux's eventfd syscall"
 repository = "https://github.com/jsgf/eventfd-rust.git"
 readme = "README.md"
 license = "MIT"
 
-[dependencies.nix]
-git = "https://github.com/carllerche/nix-rust.git"
-features = [ "eventfd" ]
+[dependencies]
+nix = "0.11"


### PR DESCRIPTION
Quick fix to make the library usable with recent rust version. The change is not backward compatible because the eventfd flags in nix crate have changed and I think it's better to use those flags instead of inventing our own and error type in return values have changed from io error to nix error.