### PR TITLE
Add Android support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg(target_os = "linux")]
+#![cfg(any(target_os = "linux", target_os = "android"))]
 //! EventFD binding
 //!
 //! This crate implements a simple binding for Linux eventfd(). See


### PR DESCRIPTION
Android uses the same Linux kernel, so this crate is also valid for it.